### PR TITLE
Added -UseBasicParsing to Invoke-WebRequest

### DIFF
--- a/function/Get-SQLServerUpdates.ps1
+++ b/function/Get-SQLServerUpdates.ps1
@@ -118,7 +118,7 @@ function Get-SqlServerUpdate
         {
             # enable TLS 1.2
             [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-            $html = Invoke-WebRequest -Uri $WebsiteAddress
+            $html = Invoke-WebRequest -Uri $WebsiteAddress -UseBasicParsing
             $content = $parser.ParseDocument($html);
             Write-Verbose ("{0};Invoke-WebRequest" -f $ElapsedTime.Elapsed)
         }
@@ -169,7 +169,7 @@ function Get-SqlServerUpdate
         # $SQL = 'SQL Server 2008'
         try
         {
-            $webHtml = Invoke-WebRequest -Uri $VersionSQL.$SQL.href
+            $webHtml = Invoke-WebRequest -Uri $VersionSQL.$SQL.href -UseBasicParsing
             $ListUpdates = $parser.ParseDocument($webHtml);
         }
         catch


### PR DESCRIPTION
Added -UseBasicParsing to Invoke-WebRequest so that it works on computers where Internet Explorer hasn't been initialized yet.

Resolves https://stackoverflow.com/questions/38005341/the-response-content-cannot-be-parsed-because-the-internet-explorer-engine-is-no